### PR TITLE
support C++ that treat shader file content as a raw string literal

### DIFF
--- a/grammars/shadercode-glsl.cson
+++ b/grammars/shadercode-glsl.cson
@@ -76,6 +76,16 @@
     'end': '\\n'
   }
   {
+    'name': 'quoted.double.glsl'
+    'begin': '^(r|R)"\\($'
+    'end': '^\\)"$'
+    'patterns': [
+      {
+        'include': "$self"
+      }
+    ]
+  }
+  {
     'include': 'source.c'
   }
 ]

--- a/spec/c++_test.glsl
+++ b/spec/c++_test.glsl
@@ -1,0 +1,8 @@
+R"(
+#version 420 core
+
+void main(void)
+{
+    gl_Position = vec4(0.0, 0.0, 0.0, 1.0);
+}
+)"


### PR DESCRIPTION
With c++11, we can import a glsl file :

```c++
const std::string shader_source =
#include "c++_test.glsl"
;
```